### PR TITLE
Use "git archive" for the "make releasetar" process

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -147,6 +147,7 @@ Monthday, Month DD, YYYY:
         find Homebrew packages.
       Handle some Autoconf/make errors better.
       Fix "make releasetar" on AIX, OpenBSD and Solaris.
+      Use "git archive" for the "make releasetar" process.
       Fix compiling on Solaris 9/SPARC and 11/AMD64.
       Address assorted compiler warnings.
       Fix cross-building on Linux for Windows with mingw32 for Win64

--- a/Makefile.in
+++ b/Makefile.in
@@ -424,6 +424,10 @@ EXTRA_DIST = \
 
 TEST_DIST = `git ls-files tests | grep -v 'tests/\..*'`
 
+RELEASE_FILES = $(COMMON_C_SRC) $(HDR) $(MAN1) $(MAN3PCAP_EXPAND) \
+	$(MAN3PCAP_NOEXPAND) $(MANFILE) $(MANMISC) $(EXTRA_DIST) \
+	$(TEST_DIST)
+
 all: libpcap.a shared $(BUILD_RPCAPD) libpcap.pc pcap-config
 
 libpcap.a: $(OBJ)
@@ -818,19 +822,16 @@ tags: $(TAGFILES)
 	ctags -wtd $(TAGFILES)
 
 releasetar:
-	@autoreconf -f && \
-	name=$(PROG)-`cat VERSION` && \
-	   mkdir $$name && \
-	   tar cf - $(COMMON_C_SRC) $(HDR) $(MAN1) \
-	      $(MAN3PCAP_EXPAND) $(MAN3PCAP_NOEXPAND) $(MANFILE) \
-	      $(MANMISC) $(EXTRA_DIST) $(TEST_DIST) >/dev/null && \
-	   tar cf - $(COMMON_C_SRC) $(HDR) $(MAN1) \
-	      $(MAN3PCAP_EXPAND) $(MAN3PCAP_NOEXPAND) $(MANFILE) \
-	      $(MANMISC) $(EXTRA_DIST) $(TEST_DIST) | \
-	      (cd $$name; tar xf -) && \
-	   tar cf - $$name >/dev/null && \
-	   tar cf - $$name | gzip >$$name.tar.gz && \
-	   rm -rf $$name
+	@TAG=$(PROG)-`cat VERSION` && \
+	if git show-ref --tags --quiet --verify -- "refs/tags/$$TAG"; then \
+	    git archive --prefix="$$TAG"/ -o "$$TAG".tar.gz "$$TAG" \
+	    $(RELEASE_FILES) && \
+	    echo "Archive build from tag $$TAG."; \
+	else \
+	    git archive --prefix="$$TAG"/ -o "$$TAG".tar.gz HEAD \
+	    $(RELEASE_FILES) && \
+	    echo "No $$TAG tag. Archive build from HEAD."; \
+	fi
 
 rc1 rc2 rc3 rc4 rc5:
 	@VER=`cat $(srcdir)/VERSION`; \


### PR DESCRIPTION
Use the release tag if it exists or use HEAD.

Remove the "autoreconf -f" command, because it changes the configure file locally in an uncontrolled way (runstatedir, #define LARGE_OFF_T, etc.) depending on the autoconf version. This command is run in the release process before a commit and we can choose the parts that will be added in the commit.

Note:
The following target (rcX) must be updated ou removed in a next step because it was using "autoreconf -f" (via "make releasetar") and it changes the VERSION and configure files locally.

This change
1) Ensures that we only release files from tag/HEAD, not locally
   modified ones.
2) Avoids disclosing personal data such as the username/group of the
   local user.
3) Puts by default a umask of 0002, which turns off the world write bit
   on files in the archive.
4) Avoids problems on some OSes (no more tar, Git builtin tar.gz
   handling).